### PR TITLE
This fixes a bunch of missing bindings with the latest SLIME.

### DIFF
--- a/slime.scm
+++ b/slime.scm
@@ -3,7 +3,9 @@
                swank:swank-require
                swank:autodoc
                swank:create-repl
+               swank-repl:create-repl
                swank:listener-eval
+               swank-repl:listener-eval
                swank:compile-string-for-emacs
                swank:interactive-eval
                swank:interactive-eval-region

--- a/swank-chicken.scm
+++ b/swank-chicken.scm
@@ -315,6 +315,8 @@
 (define (swank:create-repl . _)
   '(:ok ("CSI" "CSI")))
 
+(define swank-repl:create-repl swank:create-repl)
+
 ;; Parse `str' into a list of forms.
 (define (string->forms str)
   (define (get-forms)
@@ -336,6 +338,8 @@
           `(:ok (:values ,@(map (lambda (r)
                                   (fmt #f (wrt r)))
                                 results))))))
+
+(define swank-repl:listener-eval swank:listener-eval)
 
 ;; "Compile" a string. For us this just means eval and discard the
 ;; results, the behaviour of which might be different to what SLIME


### PR DESCRIPTION
Looks like someone working on SLIME decided to place the repl bindings in their own namespace. Simply creating additional bindings to the original functions appears to work.
