### PR TITLE
Apropos is broken with the latest version of SLIME

### DIFF
--- a/slime.meta
+++ b/slime.meta
@@ -7,7 +7,8 @@
  (needs symbol-utils
         apropos
 	chicken-doc
-        fmt)
+        fmt
+	trace)
                     
  (test-depends test)
 

--- a/slime.scm
+++ b/slime.scm
@@ -29,7 +29,16 @@
                swank:apropos-list-for-emacs
                swank:set-default-directory
                swank:default-directory
-               swank:init-presentations)
+               swank:init-presentations
+	       swank-trace-dialog:dialog-toggle-trace
+	       swank-trace-dialog:dialog-untrace
+	       swank-trace-dialog:report-specs
+	       swank-trace-dialog:report-total
+	       swank-trace-dialog:report-partial-tree
+	       swank-trace-dialog:inspect-trace-part
+	       swank-trace-dialog:report-trace-detail
+	       swank-trace-dialog:clear-trace-tree
+	       swank-trace-dialog:dialog-untrace-all)
   (import scheme
           chicken irregex)
   (use ports

--- a/slime.setup
+++ b/slime.setup
@@ -11,5 +11,5 @@
   '("slime.o" "slime.so" "slime.import.so"
     "chicken-slime.el")
   ; Assoc list with properties for your extension:
-  '((version 0.1)
+  '((version 0.2)
     (static "slime.o"))) ;; for static linking

--- a/swank-chicken.scm
+++ b/swank-chicken.scm
@@ -28,7 +28,8 @@
                    chicken-doc
 		   extras
                    fmt
-                   srfi-14)
+                   srfi-14
+		   trace)
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -606,4 +607,52 @@
 (define (swank:init-presentations . _) '(:ok nil))
 
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Trace
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+; (:ok "DEFUN is now traced for trace dialog")
+; (:ok "DEFUN is now untraced for trace dialog")
+; (:debug 1 1 ("invalid function name: 12312" "   [Condition of type SIMPLE-TYPE-ERROR]" nil)
+(define (swank-trace-dialog:dialog-toggle-trace symbol) '(:ok nil))
+(define (swank-trace-dialog:dialog-untrace symbol) '(:ok nil))
+
+; (:ok (common-lisp:defun))
+(define (swank-trace-dialog:report-specs) '(:ok nil))
+
+; (:ok 0) ; number of recorded traces
+(define (swank-trace-dialog:report-total) '(:ok 0))
+
+; (:ok
+; (((0 nil common-lisp-user::foo nil
+;      (...))
+;   (1 nil common-lisp-user::foo nil
+;      (...)))
+;  0 slime-trace-dialog-fetch-key-83333))
+(define (swank-trace-dialog:report-partial-tree fetch-key))
+
+; (:ok
+;   (:title "#<BIT {2}>" :id 0 :content
+; 	  (("Value: 1 = #x00000001 = #o1 = #b1 = 1.e+0" "\n" "Code-char" ": "
+; 	    (:value "#\\Soh" 1)
+; 	    "\n" "Integer-length" ": "
+; 	    (:value "@0=1" 2)
+; 	    "\n" "Universal-time" ": "
+; 	    (:value "\"1899-12-31T16:00:01-08:00\"" 3)
+; 	    "\n")
+; 	   14 0 500)))
+; swank-trace-dialog:inspect-trace-part 0 0 :retval
+(define (swank-trace-dialog:inspect-trace-part id return-value-index detail))
+
+; (:ok
+;   (5 nil common-lisp-user::foo nil
+;      ((0 "1"))
+;      nil "#<5: FOO>")
+(define (swank-trace-dialog:report-trace-detail id)
+  )
+
+; (:ok nil)
+(define (swank-trace-dialog:clear-trace-tree))
+
+; (:ok nil)
+(define (swank-trace-dialog:dialog-untrace-all))


### PR DESCRIPTION
But simply commenting out an otherwise unused field appears to fix it. Hurray?
